### PR TITLE
Update alpine image to latest available versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14.1-alpine3.11 as builder
+FROM golang:1.19-alpine3.17 as builder
 
 RUN apk add --update --no-cache ca-certificates tzdata git make bash && update-ca-certificates
 
@@ -7,7 +7,7 @@ WORKDIR /opt
 
 RUN git update-index --refresh; make token-refresher
 
-FROM alpine:3.10 as runner
+FROM alpine:3.17 as runner
 
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /opt/token-refresher /bin/token-refresher


### PR DESCRIPTION
There has been some vulnerabilities on the base image since we have not upgraded them for a long time.
Taking this opportunity to upgrade the builder image and runner images

Successfully built the container

![image](https://user-images.githubusercontent.com/8926556/212718484-16e7227f-df53-4876-808f-df00f105efac.png)
